### PR TITLE
Lagt til 3 nye felter i pensjonsinformasjonV1

### DIFF
--- a/pensjonsinformasjon-v1-tjenestespesifikasjon/src/main/resources/pensjonsinformasjon/v1/v1.KravHistorikk.xsd
+++ b/pensjonsinformasjon-v1-tjenestespesifikasjon/src/main/resources/pensjonsinformasjon/v1/v1.KravHistorikk.xsd
@@ -5,10 +5,12 @@
 
   <xs:complexType name="v1.KravHistorikk">
       <xs:sequence>
+        <xs:element form="qualified" name="kravId" type="xs:string"/>
          <xs:element form="qualified" name="kravType" type="xs:string"/>
          <xs:element form="qualified" name="mottattDato" type="xs:dateTime"/>
          <xs:element form="qualified" name="virkningstidspunkt" type="xs:dateTime"/>
          <xs:element form="qualified" name="status" type="xs:string"/>
+        <xs:element form="qualified" minOccurs="0" name="kravArsak" type="xs:string"/>
       </xs:sequence>
   </xs:complexType>
 </xs:schema>

--- a/pensjonsinformasjon-v1-tjenestespesifikasjon/src/main/resources/pensjonsinformasjon/v1/v1.Vedtak.xsd
+++ b/pensjonsinformasjon-v1-tjenestespesifikasjon/src/main/resources/pensjonsinformasjon/v1/v1.Vedtak.xsd
@@ -14,6 +14,7 @@
          <xs:element form="qualified" minOccurs="0" name="boddArbeidetUtland" type="xs:boolean"/>
          <xs:element form="qualified" minOccurs="0" name="vurdereTrygdeAvtale" type="xs:boolean"/>
          <xs:element form="qualified" minOccurs="0" name="datoFattetVedtak" type="xs:dateTime"/>
+         <xs:element form="qualified" name="vedtakStatus" type="xs:string"/>
       </xs:sequence>
   </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Ikke behov for å bume til V2 da det kun er 2 konsumenter ( eessi-pensjon-fagmodul og dsop-ufo) hvor begge godtar endringen