### PR TITLE
Legger tilbake opprinnelig binding for å slippe endringer i Gosys.

### DIFF
--- a/udi-personstatus-v1/src/main/wsdl/bindings.xml
+++ b/udi-personstatus-v1/src/main/wsdl/bindings.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jaxb:bindings xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    jaxb:version="2.0">
-    <jaxb:bindings schemaLocation="MT_1067_NAV_Data_v1.xsd" node="/xsd:schema"/>
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+               jaxb:version="2.0">
+    <jaxb:bindings schemaLocation="MT_1067_NAV_Data_v1.xsd" node="/xsd:schema">
+        <jaxb:schemaBindings>
+            <jaxb:nameXmlTransform>
+                <jaxb:typeName prefix="WS"/>
+                <jaxb:elementName prefix="WS"/>
+            </jaxb:nameXmlTransform>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
 </jaxb:bindings>


### PR DESCRIPTION
Benyttes kun av gosys - gammel versjon som er i bruk p.t. ligger ikke i gpr gjør denne lik til nexus-versjonen