### PR TITLE
Slettet CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @navikt/nav-it-github-users


### PR DESCRIPTION
Org admins kan heller gi `nav-it-github-users` skrivetilganger til repoet. 🙏 