### PR TITLE
Endre datatypen til fagsystemSakId i Ytelseskontrakt_v3

### DIFF
--- a/ytelseskontrakt-v3-tjenestespesifikasjon/src/main/wsdl/tjenestespesifikasjon/no/nav/tjeneste/virksomhet/ytelseskontrakt/v3/informasjon/ytelseskontrakt/ytelseskontrakt.xsd
+++ b/ytelseskontrakt-v3-tjenestespesifikasjon/src/main/wsdl/tjenestespesifikasjon/no/nav/tjeneste/virksomhet/ytelseskontrakt/v3/informasjon/ytelseskontrakt/ytelseskontrakt.xsd
@@ -110,7 +110,7 @@ kan valgfritt returneres med eller uten tidssone av tilbyder. Dette må håndter
   <xsd:complexType name="Ytelseskontrakt">
     <xsd:sequence>
       <xsd:element name="datoKravMottatt" type="xsd:date"/>
-      <xsd:element minOccurs="0" name="fagsystemSakId" type="xsd:int">
+      <xsd:element minOccurs="0" name="fagsystemSakId" type="xsd:string">
         <xsd:annotation>
           <xsd:documentation>Unik id til ytelseskontrakt-saken vedtaket eksisterer på = saksnummer i Arena.</xsd:documentation>
         </xsd:annotation>


### PR DESCRIPTION
- Endret datatypen til fagsystemSakId fra int til string for å unngå overflow.