### PR TITLE
Setter fetch-depth til 0

### DIFF
--- a/.github/workflows/releaseGithub.yml
+++ b/.github/workflows/releaseGithub.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set release tag
         run: |
           COMMIT_COUNT=$(git rev-list --all --count)


### PR DESCRIPTION
Slik at `git rev-list --all --count` skal kunne telle opp alle commits og gi riktig tall. Uten denne endringen så svarer den med tallet 1 som gir feil releaseversjon

Dette ble et behov etter oppgradering av checkout fra versjon 1 til 4