### PR TITLE
Synket YtelseVedtak_v1 WSDL med versjon 1.0.1 i Nexus som Arena bruker

### DIFF
--- a/nav-ytelsevedtak-v1-tjenestespesifikasjon/src/main/wsdl/no/nav/tjeneste/virksomhet/ytelseVedtak/v1/YtelseVedtakV1.wsdl
+++ b/nav-ytelsevedtak-v1-tjenestespesifikasjon/src/main/wsdl/no/nav/tjeneste/virksomhet/ytelseVedtak/v1/YtelseVedtakV1.wsdl
@@ -1,12 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1"
-    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="YtelseVedtakV1"
-    targetNamespace="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1">
-    <wsdl:types>
-        <schema targetNamespace="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1" xmlns="http://www.w3.org/2001/XMLSchema"
-            xmlns:feil="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/feil" xmlns:meld="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/meldinger">
-            <import schemaLocation="feil/feil.xsd" namespace="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/feil"></import>
-            <import schemaLocation="meldinger/meldinger.xsd" namespace="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/meldinger"></import>
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="YtelseVedtakV1" targetNamespace="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+  <wsdl:types>
+    <schema targetNamespace="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:feil="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/feil" xmlns:meld="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/meldinger">
+            <import namespace="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/feil" schemaLocation="feil/feil.xsd"/>
+            <import namespace="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/meldinger" schemaLocation="meldinger/meldinger.xsd"/>
             <element name="ping">
                 <complexType>
                     <sequence>
@@ -22,81 +19,94 @@
             <element name="finnYtelseVedtakListeResponse">
                 <complexType>
                     <sequence>
-                        <element name="response" type="meld:FinnYtelseVedtakListeResponse" minOccurs="0"></element>
+                        <element minOccurs="0" name="response" type="meld:FinnYtelseVedtakListeResponse"/>
                     </sequence>
                 </complexType>
             </element>
             <element name="finnYtelseVedtakListe">
                 <complexType>
                     <sequence>
-                        <element name="request" type="meld:FinnYtelseVedtakListeRequest"></element>
+                        <element name="request" type="meld:FinnYtelseVedtakListeRequest"/>
                     </sequence>
                 </complexType>
             </element>
-            <element name="finnYtelseVedtakListeSikkerhetsbegrensning" type="feil:Sikkerhetsbegrensning"></element>
-            <element name="finnYtelseVedtakListeUgyldigInput" type="feil:UgyldigInput"></element>
+            <element name="finnYtelseVedtakListeSikkerhetsbegrensning" type="feil:Sikkerhetsbegrensning"/>
+            <element name="finnYtelseVedtakListeUgyldigInput" type="feil:UgyldigInput"/>
         </schema>
-    </wsdl:types>
-    <wsdl:message name="pingRequest">
-        <wsdl:part element="tns:ping" name="parameters" />
-    </wsdl:message>
-    <wsdl:message name="pingResponse">
-        <wsdl:part element="tns:pingResponse" name="parameters" />
-    </wsdl:message>
-    <wsdl:message name="finnYtelseVedtakListeRequest">
-        <wsdl:part name="parameters" element="tns:finnYtelseVedtakListe"></wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="finnYtelseVedtakListeResponse">
-        <wsdl:part name="parameters" element="tns:finnYtelseVedtakListeResponse"></wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="finnYtelseVedtakListeSikkerhetsbegrensning">
-        <wsdl:part name="sikkerhetsbegrensning" element="tns:finnYtelseVedtakListeSikkerhetsbegrensning"></wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="finnYtelseVedtakListeUgyldigInput">
-        <wsdl:part name="ugyldigInput" element="tns:finnYtelseVedtakListeUgyldigInput"></wsdl:part>
-    </wsdl:message>
-    <wsdl:portType name="YtelseVedtak_v1">
-        <wsdl:operation name="ping">
-            <wsdl:input message="tns:pingRequest" name="ping" />
-            <wsdl:output message="tns:pingResponse" name="pingResponse" />
-        </wsdl:operation>
-        <wsdl:operation name="finnYtelseVedtakListe">
-            <wsdl:input message="tns:finnYtelseVedtakListeRequest" name="finnYtelseVedtakListe"></wsdl:input>
-            <wsdl:output message="tns:finnYtelseVedtakListeResponse" name="finnYtelseVedtakListeResponse"></wsdl:output>
-            <wsdl:fault name="sikkerhetsbegrensning" message="tns:finnYtelseVedtakListeSikkerhetsbegrensning"></wsdl:fault>
-            <wsdl:fault name="ugyldigInput" message="tns:finnYtelseVedtakListeUgyldigInput"></wsdl:fault>
-        </wsdl:operation>
-    </wsdl:portType>
-    <wsdl:binding name="YtelseVedtak_v1Binding" type="tns:YtelseVedtak_v1">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
-        <wsdl:operation name="ping">
-            <soap:operation soapAction="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/ping" />
-            <wsdl:input name="ping">
-                <soap:body use="literal" />
-            </wsdl:input>
-            <wsdl:output name="pingResponse">
-                <soap:body use="literal" />
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="finnYtelseVedtakListe">
-            <soap:operation soapAction="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/finnYtelseVedtakListe" />
-            <wsdl:input name="finnYtelseVedtakListe">
-                <soap:body use="literal" />
-            </wsdl:input>
-            <wsdl:output name="finnYtelseVedtakListeResponse">
-                <soap:body use="literal" />
-            </wsdl:output>
-            <wsdl:fault name="sikkerhetsbegrensning">
-                <soap:fault use="literal" name="sikkerhetsbegrensning" />
-            </wsdl:fault>
-            <wsdl:fault name="ugyldigInput">
-                <soap:fault use="literal" name="ugyldigInput" />
-            </wsdl:fault>
-        </wsdl:operation>
-    </wsdl:binding>
-    <wsdl:service name="YtelseVedtak_v1">
-        <wsdl:port binding="tns:YtelseVedtak_v1Binding" name="YtelseVedtak_v1Port">
-            <soap:address location="https://arena.adeo.no/ail_ws/YtelseVedtak_v1" />
-        </wsdl:port>
-    </wsdl:service>
+  </wsdl:types>
+  <wsdl:message name="pingRequest">
+    <wsdl:part name="parameters" element="tns:ping">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="finnYtelseVedtakListeRequest">
+    <wsdl:part name="parameters" element="tns:finnYtelseVedtakListe">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="pingResponse">
+    <wsdl:part name="parameters" element="tns:pingResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="finnYtelseVedtakListe_ugyldigInput">
+    <wsdl:part name="ugyldigInput" element="tns:finnYtelseVedtakListeUgyldigInput">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="finnYtelseVedtakListeResponse">
+    <wsdl:part name="parameters" element="tns:finnYtelseVedtakListeResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="finnYtelseVedtakListe_sikkerhetsbegrensning">
+    <wsdl:part name="sikkerhetsbegrensning" element="tns:finnYtelseVedtakListeSikkerhetsbegrensning">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="YtelseVedtak_v1">
+    <wsdl:operation name="ping">
+      <wsdl:input name="ping" message="tns:pingRequest">
+    </wsdl:input>
+      <wsdl:output name="pingResponse" message="tns:pingResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="finnYtelseVedtakListe">
+      <wsdl:input name="finnYtelseVedtakListe" message="tns:finnYtelseVedtakListeRequest">
+    </wsdl:input>
+      <wsdl:output name="finnYtelseVedtakListeResponse" message="tns:finnYtelseVedtakListeResponse">
+    </wsdl:output>
+      <wsdl:fault name="sikkerhetsbegrensning" message="tns:finnYtelseVedtakListe_sikkerhetsbegrensning">
+    </wsdl:fault>
+      <wsdl:fault name="ugyldigInput" message="tns:finnYtelseVedtakListe_ugyldigInput">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="YtelseVedtak_v1Binding" type="tns:YtelseVedtak_v1">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsaw:UsingAddressing/>
+    <wsdl:operation name="ping">
+      <soap:operation soapAction="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/YtelseVedtak_v1/pingRequest"/>
+      <wsdl:input name="ping">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="pingResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="finnYtelseVedtakListe">
+      <soap:operation soapAction="http://nav.no/tjeneste/virksomhet/ytelseVedtak/v1/YtelseVedtak_v1/finnYtelseVedtakListeRequest"/>
+      <wsdl:input name="finnYtelseVedtakListe">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="finnYtelseVedtakListeResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="sikkerhetsbegrensning">
+        <soap:fault name="sikkerhetsbegrensning" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ugyldigInput">
+        <soap:fault name="ugyldigInput" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="YtelseVedtak_v1">
+    <wsdl:port name="YtelseVedtak_v1Port" binding="tns:YtelseVedtak_v1Binding">
+      <soap:address location="https://arena.adeo.no/ail_ws/YtelseVedtak_v1"/>
+    </wsdl:port>
+  </wsdl:service>
 </wsdl:definitions>


### PR DESCRIPTION
- Synket opp YtelseVedtak_v1 WSDL med versjon 1.0.1 som er deployet på Nexus (og som Arena-tjenesten er basert på). Bakgrunnen er at Team Motta og Beregne oppdaget avvik i action-verdien for finnYtelseVedtakListe (og forsåvidt for ping).